### PR TITLE
Check for combat lockdown in PlayerEnteringWorld

### DIFF
--- a/Outfitter.lua
+++ b/Outfitter.lua
@@ -1333,7 +1333,11 @@ function Outfitter:PlayerEnteringWorld()
 
 	self:FlushInventoryCache()
 
-	self:RegenEnabled()
+	if InCombatLockdown() then
+		self:RegenDisabled()
+	else
+		self:RegenEnabled()
+	end
 	self:UpdateAuraStates()
 
 	self:ScheduleUpdateZone()


### PR DESCRIPTION
Check for combat lockdown in PlayerEnteringWorld to make sure we call RegenEnabled or RegenDisabled correctly.