### PR TITLE
Handle tooltip lines with no left text

### DIFF
--- a/Libraries/MC2TooltipLib/MC2TooltipLib.lua
+++ b/Libraries/MC2TooltipLib/MC2TooltipLib.lua
@@ -39,7 +39,8 @@ function Addon.TooltipLib:TooltipLeftLines(tooltip)
 			tooltip[line] = fontString
 		end
 		
-		return fontString:GetText()
+		-- a generic-for stops at the first nil return
+		return fontString:GetText() or ""
 	end
 end
 

--- a/OutfitterInventory.lua
+++ b/OutfitterInventory.lua
@@ -479,14 +479,16 @@ function Outfitter._ItemInfo:ParseGemLinkForUniqueEquips(link)
 
 	for line in Outfitter.TooltipLib:TooltipLines(tooltip) do
 		--if line.leftText then print(line.leftText) end
+		local leftText = line.leftText or ""
+
 		-- Check for Unique-Equipped
-		local type, count = line.leftText:match(Outfitter.cUniqueEquippedSearchPattern)
+		local type, count = leftText:match(Outfitter.cUniqueEquippedSearchPattern)
 		if type then
 			--print("Unique") --DAC
 			return type, tonumber(count)
 		end
 
-		local matchString = line.leftText:match("^Unique%-Equipped$")
+		local matchString = leftText:match("^Unique%-Equipped$")
 		if matchString then
 			--print("Found unique equipped gem", gemName) --DAC
 			return gemName, 1
@@ -497,6 +499,10 @@ function Outfitter._ItemInfo:ParseGemLinkForUniqueEquips(link)
 end
 
 function Outfitter._ItemInfo:ParseTooltipLine(text, color)
+	if not text then
+		return
+	end
+
 	-- Check for Binds on Equip
 	if text == ITEM_BIND_ON_EQUIP then
 		self.BoE = true


### PR DESCRIPTION
Blank separator lines have no leftText.

ParseTooltipLine indexes it during inventory sync -- full stack in #170.

ParseGemLinkForUniqueEquips calls line.leftText:match the same way; that fires when hovering a gemmed item.

TooltipLeftLines returns leftText straight into a generic for, and nil ends the loop, so StatsForTooltip stops at the first separator.